### PR TITLE
Fixed possible PTA on Windows Server or other NTFS based systems

### DIFF
--- a/resources/api/upload.py
+++ b/resources/api/upload.py
@@ -92,7 +92,7 @@ def upload_method():
     if "file" not in request.files:
         raise NoFileInRequest()
     file = request.files["file"]
-    if file.filename == "" or "/" in file.filename:
+    if file.filename == "" or "/" in file.filename or "\" in file.filename: # PTA protection
         raise InvalidFileName()
     if not is_file_suffix_valid(file.filename):
         raise InvalidFileSuffix()


### PR DESCRIPTION
As it is possible to use ``\`` as path delimiter on Windows Server, too, I've added it to the blacklisted chars in the URL. Otherwise this could lead to PTA's everywhere on the server as it would be possible to access any directory on the server (depending on the privileges of the script).